### PR TITLE
Feature/names and chat

### DIFF
--- a/Game/Misc/Chat/chat.gd
+++ b/Game/Misc/Chat/chat.gd
@@ -21,9 +21,12 @@ func scrollbar_changed():
 	chatbox.add_child(m)
 
 func _unhandled_key_input(event):
-	if event.is_action_pressed("Chat"):
+	if Input.is_action_pressed("Chat"):
 		$VBoxContainer/Input.select(0)
+		$VBoxContainer/Input.grab_focus()
 
 func _on_input_text_submitted(new_text):
 	rpc("chat_message", Network.unique_id, new_text)
 	$VBoxContainer/Input.text = ""
+	$VBoxContainer/Input.release_focus()
+	

--- a/Game/Misc/Chat/chat.gd
+++ b/Game/Misc/Chat/chat.gd
@@ -3,6 +3,7 @@ extends Control
 var chatmessage = preload("res://Game/Misc/Chat/chat_message.tscn")
 @onready var chatbox = $VBoxContainer/ScrollContainer/Chatbox
 @onready var scrollbar = $VBoxContainer/ScrollContainer.get_v_scroll_bar()
+@onready var input = $VBoxContainer/Input
 var max_scroll_length = 0
 
 func _ready():
@@ -17,16 +18,56 @@ func scrollbar_changed():
 @rpc("any_peer", "reliable", "call_local") func chat_message(from_id, message):
 	var m = chatmessage.instantiate()
 	var p_name = Server.player_info[from_id][0]
+	message = read_message_meta(message, m)
 	m.text = "%s: %s" % [p_name, message]
 	chatbox.add_child(m)
 
 func _unhandled_key_input(event):
 	if Input.is_action_pressed("Chat"):
-		$VBoxContainer/Input.select(0)
-		$VBoxContainer/Input.grab_focus()
+		
+		if input.text.length() > 0:
+			input.select(0)
+		input.grab_focus()
 
 func _on_input_text_submitted(new_text):
 	rpc("chat_message", Network.unique_id, new_text)
-	$VBoxContainer/Input.text = ""
-	$VBoxContainer/Input.release_focus()
+	input.text = ""
+	input.release_focus()
 	
+
+func read_message_meta(message, message_node):
+	
+	var message_lower = message.to_lower()
+	
+	if message_lower.begins_with("m{"):
+		
+		var meta_begin = message.find("m{") + 2
+		var meta_end = message.find("}") - 2
+		var meta = message.substr(meta_begin, meta_end)
+		var meta_array = meta.split(",")
+		
+		for pair in meta_array:
+			
+			var pair_array = pair.split("=")
+			
+			var key = pair_array[0]
+			var value = ""
+			
+			if pair_array.size() != 1:
+				value = pair_array[1]
+			
+			print("%s = %s" %[key, value])
+			
+			match key:
+				
+				"color": #takes value
+					if value == "":
+						return
+					message_node.self_modulate = Color(value)
+				
+				"dork": #doesn't take value
+					message = "Yo bro, you're a dork! Megadork!"
+		
+		message = message.trim_prefix("m{").trim_prefix(meta).trim_prefix("}")
+	
+	return message

--- a/Game/Misc/Chat/chat.gd
+++ b/Game/Misc/Chat/chat.gd
@@ -6,9 +6,14 @@ var chatmessage = preload("res://Game/Misc/Chat/chat_message.tscn")
 @onready var input = $VBoxContainer/Input
 var max_scroll_length = 0
 
+var chatlog = []
+
+var fade = false
+
 func _ready():
 	scrollbar.changed.connect(scrollbar_changed)
 	max_scroll_length = scrollbar.max_value
+	chat_message(0, "{color=aaaaaa}Welcome. Hit T to chat.")
 
 func scrollbar_changed():
 	if max_scroll_length != scrollbar.max_value:
@@ -17,32 +22,51 @@ func scrollbar_changed():
 
 @rpc("any_peer", "reliable", "call_local") func chat_message(from_id, message):
 	var m = chatmessage.instantiate()
-	var p_name = Server.player_info[from_id][0]
+	
+	chatlog.append(message)
+	
 	message = read_message_meta(message, m)
-	m.text = "%s: %s" % [p_name, message]
+	
+	m.text = message
+	
+	var p_name = ""
+	if from_id != 0:
+		p_name = Server.player_info[from_id][0]
+		m.text = "%s: %s" % [p_name, message]
+	
 	chatbox.add_child(m)
+	
+	fade = false
+	modulate.a = 1
+	$FadeTimer.start()
 
 func _unhandled_key_input(event):
 	if Input.is_action_pressed("Chat"):
 		
-		if input.text.length() > 0:
-			input.select(0)
-		input.grab_focus()
+		if !input.has_focus():
+			
+			if input.text.length() > 0:
+				input.select(0)
+			input.grab_focus()
+			
+			
+		if input.has_focus():
+			fade = false
+			modulate.a = 1
 
 func _on_input_text_submitted(new_text):
 	rpc("chat_message", Network.unique_id, new_text)
 	input.text = ""
 	input.release_focus()
-	
 
 func read_message_meta(message, message_node):
 	
 	var message_lower = message.to_lower()
 	
-	if message_lower.begins_with("m{"):
+	if message_lower.begins_with("{"):
 		
-		var meta_begin = message.find("m{") + 2
-		var meta_end = message.find("}") - 2
+		var meta_begin = message.find("{") + 1
+		var meta_end = message.find("}") - 1
 		var meta = message.substr(meta_begin, meta_end)
 		var meta_array = meta.split(",")
 		
@@ -68,6 +92,13 @@ func read_message_meta(message, message_node):
 				"dork": #doesn't take value
 					message = "Yo bro, you're a dork! Megadork!"
 		
-		message = message.trim_prefix("m{").trim_prefix(meta).trim_prefix("}")
+		message = message.trim_prefix("{").trim_prefix(meta).trim_prefix("}")
 	
 	return message
+
+func _process(delta):
+	if modulate.a > 0 and fade:
+		modulate.a = move_toward(modulate.a, 0, delta)
+
+func _on_fade_timer_timeout():
+	fade = true

--- a/Game/Misc/Chat/chat.gd
+++ b/Game/Misc/Chat/chat.gd
@@ -1,0 +1,29 @@
+extends Control
+
+var chatmessage = preload("res://Game/Misc/Chat/chat_message.tscn")
+@onready var chatbox = $VBoxContainer/ScrollContainer/Chatbox
+@onready var scrollbar = $VBoxContainer/ScrollContainer.get_v_scroll_bar()
+var max_scroll_length = 0
+
+func _ready():
+	scrollbar.changed.connect(scrollbar_changed)
+	max_scroll_length = scrollbar.max_value
+
+func scrollbar_changed():
+	if max_scroll_length != scrollbar.max_value:
+		max_scroll_length = scrollbar.max_value
+		$VBoxContainer/ScrollContainer.scroll_vertical = max_scroll_length
+
+@rpc("any_peer", "reliable", "call_local") func chat_message(from_id, message):
+	var m = chatmessage.instantiate()
+	var p_name = Server.player_info[from_id][0]
+	m.text = "%s: %s" % [p_name, message]
+	chatbox.add_child(m)
+
+func _unhandled_key_input(event):
+	if event.is_action_pressed("Chat"):
+		$VBoxContainer/Input.select(0)
+
+func _on_input_text_submitted(new_text):
+	rpc("chat_message", Network.unique_id, new_text)
+	$VBoxContainer/Input.text = ""

--- a/Game/Misc/Chat/chat.tscn
+++ b/Game/Misc/Chat/chat.tscn
@@ -1,6 +1,12 @@
-[gd_scene load_steps=2 format=3 uid="uid://cf4xbwi3ta2ie"]
+[gd_scene load_steps=5 format=3 uid="uid://cf4xbwi3ta2ie"]
 
 [ext_resource type="Script" path="res://Game/Misc/Chat/chat.gd" id="1_x2hr5"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_o7hd7"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_mrft6"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_3g3kq"]
 
 [node name="Chat" type="Control"]
 layout_mode = 3
@@ -29,8 +35,17 @@ size_flags_horizontal = 3
 [node name="Input" type="LineEdit" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 8
-placeholder_text = "Hit T to chat"
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 3
+theme_override_styles/normal = SubResource("StyleBoxEmpty_o7hd7")
+theme_override_styles/focus = SubResource("StyleBoxEmpty_mrft6")
+theme_override_styles/read_only = SubResource("StyleBoxEmpty_3g3kq")
 context_menu_enabled = false
 virtual_keyboard_enabled = false
 
+[node name="FadeTimer" type="Timer" parent="."]
+wait_time = 6.0
+one_shot = true
+
 [connection signal="text_submitted" from="VBoxContainer/Input" to="." method="_on_input_text_submitted"]
+[connection signal="timeout" from="FadeTimer" to="." method="_on_fade_timer_timeout"]

--- a/Game/Misc/Chat/chat.tscn
+++ b/Game/Misc/Chat/chat.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://cf4xbwi3ta2ie"]
+[gd_scene load_steps=2 format=3 uid="uid://cf4xbwi3ta2ie"]
 
 [ext_resource type="Script" path="res://Game/Misc/Chat/chat.gd" id="1_x2hr5"]
-[ext_resource type="PackedScene" uid="uid://bg37kq5ktwq84" path="res://Game/Misc/Chat/chat_message.tscn" id="2_6tw1a"]
 
 [node name="Chat" type="Control"]
 layout_mode = 3
@@ -26,12 +25,6 @@ size_flags_vertical = 3
 [node name="Chatbox" type="VBoxContainer" parent="VBoxContainer/ScrollContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-
-[node name="ChatMessage" parent="VBoxContainer/ScrollContainer/Chatbox" instance=ExtResource("2_6tw1a")]
-layout_mode = 2
-
-[node name="ChatMessage2" parent="VBoxContainer/ScrollContainer/Chatbox" instance=ExtResource("2_6tw1a")]
-layout_mode = 2
 
 [node name="Input" type="LineEdit" parent="VBoxContainer"]
 layout_mode = 2

--- a/Game/Misc/Chat/chat.tscn
+++ b/Game/Misc/Chat/chat.tscn
@@ -1,0 +1,43 @@
+[gd_scene load_steps=3 format=3 uid="uid://cf4xbwi3ta2ie"]
+
+[ext_resource type="Script" path="res://Game/Misc/Chat/chat.gd" id="1_x2hr5"]
+[ext_resource type="PackedScene" uid="uid://bg37kq5ktwq84" path="res://Game/Misc/Chat/chat_message.tscn" id="2_6tw1a"]
+
+[node name="Chat" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = -832.0
+offset_bottom = -456.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_x2hr5")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
+offset_right = 320.0
+offset_bottom = 192.0
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Chatbox" type="VBoxContainer" parent="VBoxContainer/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="ChatMessage" parent="VBoxContainer/ScrollContainer/Chatbox" instance=ExtResource("2_6tw1a")]
+layout_mode = 2
+
+[node name="ChatMessage2" parent="VBoxContainer/ScrollContainer/Chatbox" instance=ExtResource("2_6tw1a")]
+layout_mode = 2
+
+[node name="Input" type="LineEdit" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 8
+placeholder_text = "Hit T to chat"
+context_menu_enabled = false
+virtual_keyboard_enabled = false
+
+[connection signal="text_submitted" from="VBoxContainer/Input" to="." method="_on_input_text_submitted"]

--- a/Game/Misc/Chat/chat_message.tscn
+++ b/Game/Misc/Chat/chat_message.tscn
@@ -1,0 +1,7 @@
+[gd_scene format=3 uid="uid://bg37kq5ktwq84"]
+
+[node name="ChatMessage" type="Label"]
+custom_minimum_size = Vector2(5, 1)
+size_flags_horizontal = 3
+text = "Coyote: Sample Text for the funsies! Check what happens when I type a longer message!"
+autowrap_mode = 3

--- a/Globals/Network/client.tscn
+++ b/Globals/Network/client.tscn
@@ -1,3 +1,6 @@
-[gd_scene format=3 uid="uid://bfngvicx1wmda"]
+[gd_scene load_steps=2 format=3 uid="uid://bfngvicx1wmda"]
+
+[ext_resource type="Script" path="res://Globals/Network/client.gd" id="1_31o5b"]
 
 [node name="Client" type="Node"]
+script = ExtResource("1_31o5b")

--- a/Globals/Network/network.gd
+++ b/Globals/Network/network.gd
@@ -38,20 +38,28 @@ func join_server():
 func client_connected(id):
 	game.create_player(id, game.default_pos)
 	if is_server:
-		Server.player_info[str(id)] = "Unconnected"
-		rpc_id(id, "request_client_info")
+		Server.player_info[id] = ["Unconnected"]
+		rpc_id(id, "request_client_info", Server.player_info, Server.server_config)
 
 func client_disconnected(id):
 	game.remove_player(id)
+	Server.player_info.erase(id)
+	
 
-@rpc("reliable") func request_client_info(): #Clientside. server asked us for our name
+@rpc("reliable") func request_client_info(server_player_info, server_config): #Clientside. server asked us for our info and gives us the server info
 	if is_client:
+		Server.player_info = server_player_info
+		Server.server_config = server_config
 		rpc_id(1, "send_client_info", [Globals.player_name], unique_id)
+		
+		for c in Server.player_info.keys():
+			if c != unique_id:
+				game.players.get_node(str(c)).get_node("Username").text = Server.player_info[c][0]
 
 @rpc("reliable", "any_peer") func send_client_info(p_info, new_p_id): #Shared. get the new client's info. #p_info is an array containing all necessary information
 	if is_server:
-		Server.player_info[str(new_p_id)] = p_info
-		print("server: " + str(Server.player_info))
+		Server.player_info[new_p_id] = p_info
+		#print("server: " + str(Server.player_info))
 		#forward the new client's necessary info to the other clients on the server
 		var ids = multiplayer.get_peers()
 		for c in ids:
@@ -59,5 +67,8 @@ func client_disconnected(id):
 				rpc_id(c, "send_client_info", p_info, new_p_id)
 	
 	if is_client:
-		Server.player_info[str(new_p_id)] = p_info
+		Server.player_info[new_p_id] = p_info
 		print("client: " + str(Server.player_info))
+		
+	
+	game.players.get_node(str(new_p_id)).get_node("Username").text = Server.player_info[new_p_id][0]

--- a/Globals/Network/network.gd
+++ b/Globals/Network/network.gd
@@ -24,7 +24,8 @@ func host_server():
 	unique_id = multiplayer.get_unique_id()
 	is_server = true
 	NetworkTime.start()
-
+	
+	Server.player_info[unique_id] = [Globals.player_name]
 
 func join_server():
 	client = ENetMultiplayerPeer.new()
@@ -34,10 +35,29 @@ func join_server():
 	is_client = true
 	NetworkTime.start()
 
-	
-
 func client_connected(id):
 	game.create_player(id, game.default_pos)
+	if is_server:
+		Server.player_info[str(id)] = "Unconnected"
+		rpc_id(id, "request_client_info")
 
 func client_disconnected(id):
 	game.remove_player(id)
+
+@rpc("reliable") func request_client_info(): #Clientside. server asked us for our name
+	if is_client:
+		rpc_id(1, "send_client_info", [Globals.player_name], unique_id)
+
+@rpc("reliable", "any_peer") func send_client_info(p_info, new_p_id): #Shared. get the new client's info. #p_info is an array containing all necessary information
+	if is_server:
+		Server.player_info[str(new_p_id)] = p_info
+		print("server: " + str(Server.player_info))
+		#forward the new client's necessary info to the other clients on the server
+		var ids = multiplayer.get_peers()
+		for c in ids:
+			if c != unique_id: #but make sure it's not executed on the severside
+				rpc_id(c, "send_client_info", p_info, new_p_id)
+	
+	if is_client:
+		Server.player_info[str(new_p_id)] = p_info
+		print("client: " + str(Server.player_info))

--- a/Globals/Network/network.gd
+++ b/Globals/Network/network.gd
@@ -65,6 +65,8 @@ func client_disconnected(id):
 		for c in ids:
 			if c != unique_id: #but make sure it's not executed on the severside
 				rpc_id(c, "send_client_info", p_info, new_p_id)
+		
+		game.get_node("GlobalUI/CanvasLayer/Chat").rpc("chat_message", 0, "{color=yellow}%s has joined the game" %[Server.player_info[new_p_id][0]])
 	
 	if is_client:
 		Server.player_info[new_p_id] = p_info

--- a/Globals/Network/server.gd
+++ b/Globals/Network/server.gd
@@ -11,4 +11,5 @@ var server_info = {
 
 var player_info = {
 	#"123456789": "Coyote"
+	
 }

--- a/Globals/Network/server.gd
+++ b/Globals/Network/server.gd
@@ -1,3 +1,14 @@
 extends Node
 
 var game = null
+
+var server_config = {
+	"tickrate": 60,
+}
+
+var server_info = {
+}
+
+var player_info = {
+	#"123456789": "Coyote"
+}

--- a/Globals/Network/server.tscn
+++ b/Globals/Network/server.tscn
@@ -1,3 +1,6 @@
-[gd_scene format=3 uid="uid://ycw1kiiu4cdu"]
+[gd_scene load_steps=2 format=3 uid="uid://ycw1kiiu4cdu"]
+
+[ext_resource type="Script" path="res://Globals/Network/server.gd" id="1_3r2v8"]
 
 [node name="Server" type="Node"]
+script = ExtResource("1_3r2v8")

--- a/Globals/globals.gd
+++ b/Globals/globals.gd
@@ -2,6 +2,14 @@ extends Node
 
 @export var gravity = 980
 
+var namer = NameGen.new()
+var player_name = ""
+
+func _ready():
+	randomize()
+	player_name = namer.generate_name()
+	
+
 func force_update_is_on_floor(object):
 	var old_velocity = object.velocity
 	object.velocity = Vector2.ZERO

--- a/Misc/Scripts/generate_name.gd
+++ b/Misc/Scripts/generate_name.gd
@@ -1,0 +1,31 @@
+extends Node
+class_name NameGen
+
+var adjectives = [
+	"Funny",
+	"Boring",
+	"Stinky",
+	"Goofy",
+	"Suspicious",
+	"Gothic",
+	"Scary"
+]
+
+var nouns = [
+	"Coyote",
+	"Man",
+	"Computer",
+	"Tree",
+	"Guy",
+	"Program",
+	"Game",
+	"Box",
+	"Key",
+	"Flag"
+]
+
+func generate_name():
+	var a = adjectives.pick_random()
+	var n = nouns.pick_random()
+	var finalname = a+n
+	return finalname

--- a/Scenes/menu.tscn
+++ b/Scenes/menu.tscn
@@ -11,25 +11,44 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_m88sc")
 
-[node name="MainMenu" type="VBoxContainer" parent="."]
-layout_mode = 0
-offset_right = 116.0
-offset_bottom = 66.0
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 2
+offset_right = 256.0
+offset_bottom = 101.0
 
-[node name="IP" type="LineEdit" parent="MainMenu"]
+[node name="MainMenu" type="VBoxContainer" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="IP" type="LineEdit" parent="HBoxContainer/MainMenu"]
 layout_mode = 2
 text = "127.0.0.1"
 
-[node name="Host" type="Button" parent="MainMenu"]
+[node name="Host" type="Button" parent="HBoxContainer/MainMenu"]
 layout_mode = 2
 text = "Host
 "
 
-[node name="Join" type="Button" parent="MainMenu"]
+[node name="Join" type="Button" parent="HBoxContainer/MainMenu"]
 layout_mode = 2
 text = "Join
 "
 
-[connection signal="text_changed" from="MainMenu/IP" to="." method="_on_ip_text_changed"]
-[connection signal="pressed" from="MainMenu/Host" to="." method="_on_host_pressed"]
-[connection signal="pressed" from="MainMenu/Join" to="." method="_on_join_pressed"]
+[node name="PlayerInfo" type="VBoxContainer" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="PlayerName" type="LineEdit" parent="HBoxContainer/PlayerInfo"]
+layout_mode = 2
+text = "KZT"
+placeholder_text = "Player Name"
+
+[node name="Generate" type="Button" parent="HBoxContainer/PlayerInfo"]
+layout_mode = 2
+text = "Generate"
+
+[connection signal="text_changed" from="HBoxContainer/MainMenu/IP" to="." method="_on_ip_text_changed"]
+[connection signal="pressed" from="HBoxContainer/MainMenu/Host" to="." method="_on_host_pressed"]
+[connection signal="pressed" from="HBoxContainer/MainMenu/Join" to="." method="_on_join_pressed"]
+[connection signal="text_changed" from="HBoxContainer/PlayerInfo/PlayerName" to="." method="_on_player_name_text_changed"]
+[connection signal="pressed" from="HBoxContainer/PlayerInfo/Generate" to="." method="_on_generate_pressed"]

--- a/Scenes/networkedgame.gd
+++ b/Scenes/networkedgame.gd
@@ -10,7 +10,7 @@ var player = preload("res://player.tscn")
 
 @onready var spawnpoints = $Spawnpoints
 
-var unique_id = -1
+
 var is_server = false
 var is_client = false
 var server = null
@@ -36,17 +36,23 @@ func _handle_new_peer(id: int):
 
 
 func create_player(id, pos):
-	print("Created player %s" % [id])
+	print("%s: Created player %s" % [Network.unique_id, id])
 	var p = player.instantiate()
 	p.name = str(id)
 	players.add_child(p)
 	p.global_position = pos
 	p.set_multiplayer_authority(1)
+	if Server.player_info.has(id):
+		p.get_node("Username").text = Server.player_info[id][0]
 	# Avatar's input object is owned by player
 	var input = p.find_child("PlayerInput")
 	if input != null:
 		input.set_multiplayer_authority(id)
 		print("%s: Set %s's ownership to %s" % [multiplayer.get_unique_id(), p.name, id])
+
+func remove_player(id):
+	var p = players.get_node(str(id))
+	p.queue_free()
 
 func client_connected(id):
 	print("%s connect to %s" % [multiplayer.get_unique_id(), id])

--- a/Scenes/networkedgame.tscn
+++ b/Scenes/networkedgame.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=9 format=3 uid="uid://nt17qfukiu00"]
+[gd_scene load_steps=10 format=3 uid="uid://nt17qfukiu00"]
 
 [ext_resource type="Script" path="res://Scenes/networkedgame.gd" id="1_0syg2"]
 [ext_resource type="Texture2D" uid="uid://cns6bneqppi2s" path="res://Assets/tileset_fields_wip.png" id="2_t3onm"]
 [ext_resource type="Texture2D" uid="uid://cfpgvi3nfjnv8" path="res://Assets/wood_ladder.png" id="3_8bmth"]
 [ext_resource type="Texture2D" uid="uid://cw616om8pc8qw" path="res://Assets/vecteezy_green-background-high-quality_30668435.jpg" id="4_ow6t3"]
+[ext_resource type="PackedScene" uid="uid://cf4xbwi3ta2ie" path="res://Game/Misc/Chat/chat.tscn" id="5_a2ab4"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_au32l"]
 texture = ExtResource("2_t3onm")
@@ -116,3 +117,9 @@ position = Vector2(1270, -33)
 
 [node name="4" type="Marker2D" parent="Spawnpoints"]
 position = Vector2(509, -1)
+
+[node name="GlobalUI" type="Node" parent="."]
+
+[node name="CanvasLayer" type="CanvasLayer" parent="GlobalUI"]
+
+[node name="Chat" parent="GlobalUI/CanvasLayer" instance=ExtResource("5_a2ab4")]

--- a/menu.gd
+++ b/menu.gd
@@ -10,3 +10,10 @@ func _on_join_pressed():
 
 func _on_ip_text_changed(new_text):
 	Network.connect_ip = new_text
+
+func _on_generate_pressed():
+	Globals.player_name = Globals.namer.generate_name()
+	$HBoxContainer/PlayerInfo/PlayerName.text = Globals.player_name
+
+func _on_player_name_text_changed(new_text):
+	Globals.player_name = new_text

--- a/player.tscn
+++ b/player.tscn
@@ -342,10 +342,26 @@ text = "unique_id"
 horizontal_alignment = 1
 
 [node name="State" type="Label" parent="."]
-offset_left = -24.0
+offset_left = 40.0
+offset_top = -48.0
+offset_right = 88.0
+offset_bottom = -25.0
+horizontal_alignment = 1
+
+[node name="Username" type="Label" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -40.0
 offset_top = -88.0
-offset_right = 24.0
+offset_right = 40.0
 offset_bottom = -65.0
+grow_horizontal = 2
+grow_vertical = 2
+pivot_offset = Vector2(40, 0)
+text = "Name"
 horizontal_alignment = 1
 
 [node name="RollbackSynchronizer" type="Node" parent="." node_paths=PackedStringArray("root")]

--- a/project.godot
+++ b/project.godot
@@ -67,6 +67,11 @@ interact={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"echo":false,"script":null)
 ]
 }
+Chat={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":84,"key_label":0,"unicode":116,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 


### PR DESCRIPTION
- initial server/client handshake and info exchange
- Server.server_config is forwarded to connecting clients. Server.server_config stuff can easily be expanded upon
- client/player info can easily be expanded upon since the retrieval method is based off dictionaries which is shared between all peers (can be retrieved through the Server.player_info dictionary on the server and clients)
- player username system
- chat system (chat with the T key)
- system messages
- chat metadata with a whopping 2 variables / flags currently (those being color and "dork"). This can easily be expanded upon with new variables but idk how many we might need lol.
- chat box fades after 6 seconds of inactivity and shows up when you start typing or when there's a new chat message

One big thing I want to change is to have player names be individual from the chat messages themselves so we can color them separately. 